### PR TITLE
Replace deprecated abortDelay property with RR7 streamTimeout

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -9,7 +9,8 @@ import i18n from "./localization/i18n" // your i18n configuration file
 import i18nextOpts from "./localization/i18n.server"
 import { resources } from "./localization/resource"
 
-const ABORT_DELAY = 5000
+// Reject all pending promises from handler functions after 10 seconds
+export const streamTimeout = 10000
 
 export default async function handleRequest(
 	request: Request,
@@ -38,7 +39,7 @@ export default async function handleRequest(
 
 		const { pipe, abort } = renderToPipeableStream(
 			<I18nextProvider i18n={instance}>
-				<ServerRouter abortDelay={ABORT_DELAY} context={context} url={request.url} />
+				<ServerRouter context={context} url={request.url} />
 			</I18nextProvider>,
 			{
 				[callbackName]: () => {
@@ -67,6 +68,8 @@ export default async function handleRequest(
 			}
 		)
 
-		setTimeout(abort, ABORT_DELAY)
+    // Abort the streaming render pass after 11 seconds so to allow the rejected
+    // boundaries to be flushed
+    setTimeout(abort, streamTimeout + 1000)
 	})
 }


### PR DESCRIPTION
Team forgot to remove deprecated property `abortDelay` as can be seen [in this changelog](https://github.com/remix-run/react-router/blob/main/CHANGELOG.md#patch-changes-1) and confirmed [in this discussion](https://github.com/remix-run/react-router/pull/12478#discussion_r1873644217) .

This patch replaces it with RR7 [streamTimeout](https://reactrouter.com/explanation/special-files#streamtimeout). Comments in proposed code change are taken from this page as well.

As mentioned in the ticket this "probably" fixes unnoticed issues with the streaming.

> If you are still passing abortDelay in RR v7 then it's highly likely you have a functional bug in your app because your streams are not going to timeout properly